### PR TITLE
Add example emaScalar with skew

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
     "watch": "tsc --watch",
     "postinstall": "rm -f node_modules/web3/index.d.ts"
   },
-  "bin": { "tradebot": "./dist/index.js" },
+  "bin": {
+    "tradebot": "./dist/index.js"
+  },
   "dependencies": {
     "@types/commander": "^2.12.2",
     "@types/node": "^10.9.4",
@@ -18,6 +20,6 @@
     "simple-statistics": "^6.1.1",
     "ts-node": "^7.0.1",
     "typescript": "^3.0.3",
-    "veil-js": "^0.2.2"
+    "veil-js": "^1.0.3"
   }
 }

--- a/src/BulkMarketMaker.ts
+++ b/src/BulkMarketMaker.ts
@@ -1,5 +1,4 @@
-import simpleScalar from "./scripts/simpleScalar";
-import simpleBinary from "./scripts/simpleBinary";
+import emaScalar from "./scripts/emaScalar";
 import Veil, { Market } from "veil-js";
 
 export default class BulkMarketMaker {
@@ -42,8 +41,7 @@ export default class BulkMarketMaker {
   }
 
   getMarketMakerForMarket(market: Market) {
-    if (market.type === "yesno" && market.index) return simpleBinary;
-    if (market.type === "scalar" && market.index) return simpleScalar;
+    if (market.type === "scalar" && market.index) return emaScalar;
     return null;
   }
 

--- a/src/MarketMaker.ts
+++ b/src/MarketMaker.ts
@@ -7,12 +7,16 @@ export interface IMarketMakerParams {
   orderAmount: number;
 }
 
-export const cancelAllOrders = async (veil: Veil, market: Market) => {
+export const cancelOpenOrders = async (veil: Veil, market: Market) => {
   const userOrders = await veil.getUserOrders(market);
+  let cancelCount = 0;
   for (let order of userOrders.results) {
-    if (order.status === "open") await veil.cancelOrder(order.uid);
+    if (order.status === "open") {
+      await veil.cancelOrder(order.uid);
+      cancelCount += 1;
+    }
   }
-  console.log(`Cancelled ${userOrders.results.length} orders`);
+  console.log(`Cancelled ${cancelCount} open orders`);
 };
 
 export default class MarketMaker {

--- a/src/scripts/emaScalar.ts
+++ b/src/scripts/emaScalar.ts
@@ -1,0 +1,111 @@
+import { IMarketMakerParams, cancelOpenOrders } from "../MarketMaker";
+import { Market, DataFeedEntry } from "veil-js";
+import { BigNumber } from "bignumber.js";
+
+const getEMA = async (veil: any, market: Market) => {
+  const feed = await veil.getDataFeed(market.index);
+  const normalizedEntries = feed.entries
+    .sort((a: DataFeedEntry, b: DataFeedEntry) => a.timestamp - b.timestamp)
+    .map((entry: DataFeedEntry) => parseFloat(entry.value));
+  const emaN = 10;
+  const emaAlpha = 2 / (emaN + 1);
+  const ema = normalizedEntries.reduce(
+    (lastEma: number, entry: number) =>
+      lastEma > 0 ? emaAlpha * entry + (1 - emaAlpha) * lastEma : entry
+  );
+  console.log(`${emaN}-period EMA`, ema);
+  return ema;
+};
+
+const TEN_18 = new BigNumber(10).pow(18);
+
+// Clamp a number between two bounds
+function clamp(num: number, lowerBound: number, upperBound: number) {
+  return Math.max(lowerBound, Math.min(num, upperBound));
+}
+
+// With a large net LONG position, you should skew the mid price down (so that you
+// spend less on LONGs).
+// With a large net SHORT position (a negative position), you should skew the mid
+// price up (so that you spend less on SHORTs).
+// Skew returns 0 at 0, 1 at -Infinity, and -1 at Infinity
+// At 1, it returns -0.18 (midPrice will decrease by ~18% when you hold a net position of 1)
+// At 10, it returns -0.86 (midPrice will decrease by ~86% when you hold a net position of 10)
+function positionToSkew(position: number) {
+  const sign = position > 0 ? -1 : 1;
+  return sign * (1 - Math.exp(-Math.abs(position / 5)));
+}
+
+export default async (params: IMarketMakerParams) => {
+  const { market, veil, spread, orderAmount } = params;
+  const midPrice = await getEMA(veil, market);
+  const [minPrice, maxPrice] = veil.getScalarRange(market);
+  const ethPrice = (midPrice - minPrice) / (maxPrice - minPrice);
+  const halfSpread = spread / 2;
+  const adjustedEthPrice = clamp(
+    ethPrice,
+    0.01 + halfSpread,
+    0.99 - halfSpread
+  );
+
+  if (!process.env.ETHEREUM_HTTP)
+    throw new Error(
+      "ETHEREUM_HTTP environment variable required to fetch balances"
+    );
+
+  // Get balances
+  const { longBalanceClean, shortBalanceClean } = await veil.getMarketBalances(
+    market
+  );
+  const longBalance = new BigNumber(longBalanceClean).div(TEN_18).toNumber();
+  const shortBalance = new BigNumber(shortBalanceClean).div(TEN_18).toNumber();
+
+  const netPosition = (longBalance - shortBalance) / orderAmount;
+  const skew = positionToSkew(netPosition) * halfSpread;
+
+  const bidPrice = adjustedEthPrice + skew - halfSpread;
+  const askPrice = adjustedEthPrice + skew + halfSpread;
+  const shouldCreateBid = bidPrice < 0.9; // Configurable
+  const shouldCreateAsk = askPrice > 0.1; // Configurable
+  const bidType = shortBalance > orderAmount ? "sellShort" : "buyLong";
+  const askType = longBalance > orderAmount ? "sellLong" : "buyShort";
+
+  console.log("Balances: LONG", longBalance, "   SHORT", shortBalance);
+  console.log("Skew: " + skew);
+  console.log(
+    !shouldCreateBid ? "[SKIP]" : "      ",
+    "Creating bid at " + bidPrice,
+    bidType === "sellShort" ? "[sell short]" : "[buy long]"
+  );
+  console.log(
+    !shouldCreateAsk ? "[SKIP]" : "      ",
+    "Creating ask at " + askPrice,
+    askType === "sellLong" ? "[sell long]" : "[buy short]"
+  );
+
+  await cancelOpenOrders(veil, market);
+
+  if (shouldCreateBid) {
+    const bidQuote = await veil.createQuote(
+      market,
+      bidType === "sellShort" ? "sell" : "buy",
+      bidType === "sellShort" ? "short" : "long",
+      orderAmount,
+      bidType === "sellShort" ? 1 - bidPrice : bidPrice
+    );
+    const bidOrder = await veil.createOrder(bidQuote, { postOnly: true });
+    console.log("Created bid order", bidOrder);
+  }
+
+  if (shouldCreateAsk) {
+    const askQuote = await veil.createQuote(
+      market,
+      askType === "sellLong" ? "sell" : "buy",
+      askType === "sellLong" ? "long" : "short",
+      orderAmount,
+      askType === "sellLong" ? askPrice : 1 - askPrice
+    );
+    const askOrder = await veil.createOrder(askQuote, { postOnly: true });
+    console.log("Created ask order", askOrder);
+  }
+};

--- a/src/scripts/simpleBinary.ts
+++ b/src/scripts/simpleBinary.ts
@@ -1,4 +1,4 @@
-import { IMarketMakerParams, cancelAllOrders } from "../MarketMaker";
+import { IMarketMakerParams, cancelOpenOrders } from "../MarketMaker";
 
 export default async (params: IMarketMakerParams) => {
   const { market, veil, spread, orderAmount } = params;
@@ -8,7 +8,7 @@ export default async (params: IMarketMakerParams) => {
   const askPrice = midPrice + halfSpread;
 
   // Cancel all pending orders in this market
-  await cancelAllOrders(veil, market);
+  await cancelOpenOrders(veil, market);
 
   // Create long order
   const longQuote = await veil.createQuote(

--- a/src/scripts/simpleScalar.ts
+++ b/src/scripts/simpleScalar.ts
@@ -1,4 +1,4 @@
-import { IMarketMakerParams, cancelAllOrders } from "../MarketMaker";
+import { IMarketMakerParams, cancelOpenOrders } from "../MarketMaker";
 import { Market } from "veil-js";
 
 // Return last price from market's data feed
@@ -21,7 +21,7 @@ export default async (params: IMarketMakerParams) => {
   const askPrice = adjustedEthPrice + halfSpread;
 
   // Cancel all pending orders in this market
-  await cancelAllOrders(veil, market);
+  await cancelOpenOrders(veil, market);
 
   // Create long order
   const longQuote = await veil.createQuote(


### PR DESCRIPTION
Includes:
* [X] New `emaScalar` script that uses an exponential moving average and adds skew to orders based on existing portfolio
* [X] Integrates new `getMarketBalances` Veil.js method
* [X] Rename `cancelAllOrders` method to `cancelOpenOrders` and print correct number of canceled orders